### PR TITLE
Hello Eugene,

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 This is an Angular.js directive for Brian Reavis's selectize jQuery plugin (http://brianreavis.github.io/selectize.js/).
 
-Info
-====
+# Info #
+
 Module: 'theaquaNg'
 
 Directive: 'selectize'
 
-Using:
+## Using: ##
 
-``
-  <select name="" selectize="{  delimiter: ',', persist: false }">
-``
+
+    <select 
+      name="" 
+      selectize="{  delimiter: ',', persist: false }" 
+      [selectize-data="MyAngularJSDataToWatch"]
+    >
+
+
+### Attributes: ###
+
+* `selectize` - this attribute is passed directly to [selectize.js](https://github.com/brianreavis/selectize.js/blob/master/docs/api.md)
+    whose parameters are defined in [`selectize.js's` documentation.](https://github.com/brianreavis/selectize.js/blob/master/docs/usage.md#options)
+    
+* `selectize-data` - tells the AngularJS `selectize` directive to
+    listen for any changes to the specified data *array* in the current
+    [`$scope`](https://docs.angularjs.org/guide/scope) and then to update the
+    options in the selectize widget with any new options in the updated array.
+    
+    `selectize.js` will grab the fields in each element of the array according
+    to the JSON `labelField` and `valueField` parameters that are the values of
+    the element's `selectize` attribute.  Defaults for those parameters may be
+    seen in the [`selectize.js` options documentation](https://github.com/brianreavis/selectize.js/blob/master/docs/usage.md#options)

--- a/dist/ng-selectize.js
+++ b/dist/ng-selectize.js
@@ -1,14 +1,34 @@
-(function() {
-  "use strict";
+"use strict";
 
-  angular.module("theaquaNg", ['ng']).directive("selectize", function($timeout) {
-    return {
-      restrict: "AE",
-      link: function(scope, element, attrs) {
-        return $timeout(function() {
-          return $(element).selectize(scope.$eval(attrs.selectize));
-        });
+angular.module('clientApp').directive("selectize", ['$timeout',function($timeout) {
+  return {
+    restrict: "AE",
+    link: function(scope, element, attrs) {
+      
+      var selectize_inst = null
+      
+      var load_angularjs_data = function() {
+        if (selectize_inst === null || !('selectizeData' in attrs)) { 
+          return
+        }
+        var data_array = scope.$eval(attrs.selectizeData)
+        if (!$.isArray(data_array)) {
+          return
+        }
+        for (var i in data_array) {
+          selectize_inst.addOption(data_array[i])
+        }
       }
-    };
-  });
-}).call(this);
+      
+      if ('selectizeData' in attrs) {
+        scope.$watch(attrs.selectizeData,load_angularjs_data)
+      }
+      return $timeout(function() {
+        var result = $(element).selectize(scope.$eval(attrs.selectize))
+        selectize_inst = result[0].selectize
+        load_angularjs_data()
+        return result
+      });
+    }
+  };
+}]);

--- a/dist/ng-selectize.min.js
+++ b/dist/ng-selectize.min.js
@@ -1,1 +1,0 @@
-(function(){"use strict";angular.module("theaquaNg",['ng']).directive("selectize",function($timeout){return{restrict:"AE",link:function(scope,element,attrs){return $timeout(function(){return $(element).selectize(scope.$eval(attrs.selectize));});}};});}).call(this);

--- a/src/ng-selectize.coffee
+++ b/src/ng-selectize.coffee
@@ -1,8 +1,0 @@
-"use strict"
-
-angular.module("theaquaNg", ['ng'])
-  .directive "selectize", ($timeout) ->
-    restrict: "AE"
-    link: (scope, element, attrs) ->
-      $timeout ->
-        $(element).selectize scope.$eval(attrs.selectize)


### PR DESCRIPTION
You don't seem to have either an `issues` or a `discussion` page for your
`ng-selectize` directive, so I'm communicating with you through a pull request..

My base `<select>` object is getting populated with data from an AngularJS
`$scope` attribute.  The directive that you currently have doesn't respond to
data updates or have a way of getting hooked into `$scope` field changes.

I added a new parameter to the directive called `selectize-data`, and quoting my
README doc changes:

> `selectize-data` - tells the AngularJS `selectize` directive to
> listen for any changes to the specified data _array_ in the current
> [`$scope`](https://docs.angularjs.org/guide/scope) and then to update the
> options in the selectize widget with any new options in the updated array.
> 
> `selectize.js` will grab the fields in each element of the array according
> to the JSON `labelField` and `valueField` parameters that are the values of
> the element's `selectize` attribute.  Defaults for those parameters may be
> seen in the [`selectize.js` options documentation](https://github.com/brianreavis/selectize.js/blob/master/docs/usage.md#options)

Now, when you specify `selectize-data`, it will add at `$watch` on that field of
the `scope` parameter and then update the `selectize` instance.

Unfortunately, I don't know CoffeeScript yet and I'm an amateur javascript'er.

What do you think about such a change? Is it already supported and I'm using
your directive incorrectly? Should I do something else to acheive this? Or is
this a reasonable enhancement to the directive?  Are the parameter names ok?
- Ross
